### PR TITLE
Changes in setup.py to allow using it as a dependency

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -18,5 +18,11 @@ python setup.py install --home="~"
 For more information about installing python programs see:
 https://docs.python.org/2/install/#alternate-installation-the-user-scheme
 
+It is also possible to install ANARCI using package managers like `pipenv` or `poetry`. To do so add a dependency directly from git repository:
+
+`poetry add git+https://github.com/oxpig/ANARCI.git`
+
+This way you will have it installed into your `virtualenv` directory
+
 For help see README or run:
 $ ANARCI -h

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from distutils.core import setup
 from setuptools.command.install import install
 
 
-def download_files():
+def build():
     try:
         ANARCI_LOC = os.path.dirname(importlib.util.find_spec("anarci").origin)
     except:
@@ -48,7 +48,7 @@ class Install(install):
 
     def run(self):
         super().run()
-        download_files()
+        build()
 
 
 setup(name='anarci',

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,51 @@
 # Maintained by members of OPIG #
 #                               #
 
-import shutil, os, subprocess, imp
+import shutil, os, subprocess, importlib
+
 # Clean this out if it exists
 if os.path.isdir("build"):
     shutil.rmtree("build/")
 
 from distutils.core import setup
+from setuptools.command.install import install
+
+
+def download_files():
+    try:
+        ANARCI_LOC = os.path.dirname(importlib.util.find_spec("anarci").origin)
+    except:
+        sys.stderr.write("Something isn't right. Aborting.")
+        sys.exit(1)
+
+    os.chdir("build_pipeline")
+
+    try:
+        shutil.rmtree("curated_alignments/")
+        shutil.rmtree("muscle_alignments/")
+        shutil.rmtree("HMMs/")
+        shutil.rmtree("IMGT_sequence_files/")
+        os.mkdir(os.path.join(ANARCI_LOC, "dat"))
+    except OSError:
+        pass
+
+    print('Downloading germlines from IMGT and building HMMs...')
+    proc = subprocess.Popen(["bash", "RUN_pipeline.sh"], stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+    o, e = proc.communicate()
+
+    print(o.decode())
+    print(e.decode())
+
+    shutil.copy( "curated_alignments/germlines.py", ANARCI_LOC )
+    shutil.copytree( "HMMs", os.path.join(ANARCI_LOC, "dat/HMMs/") )
+
+
+class Install(install):
+
+    def run(self):
+        super().run()
+        download_files()
+
 
 setup(name='anarci',
       version='1.3',
@@ -26,37 +65,9 @@ setup(name='anarci',
       #                         'dat/HMMs/ALL.hmm.h3m',
       #                         'dat/HMMs/ALL.hmm.h3p']},
       scripts=['bin/ANARCI'],
-      data_files = [ ('bin', ['bin/muscle', 'bin/muscle_macOS']) ]
+      install_requires=['biopython>=1.78'],
+      data_files = [ ('bin', ['bin/muscle', 'bin/muscle_macOS']) ],
+      cmdclass={'install': Install}
      )
 
-####
-import sys
-if sys.argv[1] != "install":
-    sys.exit(0)
 
-try:
-    ANARCI_LOC = imp.find_module("anarci")[1]
-except:
-    sys.stderr.write("Something isn't right. Aborting.")
-    sys.exit(1)
-
-os.chdir("build_pipeline")
-
-try:
-    shutil.rmtree("curated_alignments/")
-    shutil.rmtree("muscle_alignments/")
-    shutil.rmtree("HMMs/")
-    shutil.rmtree("IMGT_sequence_files/")
-    os.mkdir(os.path.join(ANARCI_LOC, "dat"))
-except OSError:
-    pass
-
-print('Downloading germlines from IMGT and building HMMs...')
-proc = subprocess.Popen(["bash", "RUN_pipeline.sh"], stdout = subprocess.PIPE, stderr = subprocess.PIPE)
-o, e = proc.communicate()
-
-print(o.decode())
-print(e.decode())
-
-shutil.copy( "curated_alignments/germlines.py", ANARCI_LOC )
-shutil.copytree( "HMMs", os.path.join(ANARCI_LOC, "dat/HMMs/") )


### PR DESCRIPTION
This way it will be possible to use ANARCI as a dependency. It will automatically run build pipeline when doing an install.

It still requires `HMMER` installed in a system to be able to successfully finalize installation.