### PR TITLE
Use pyHMMER to get rid of binary dependency on HMMER

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,9 @@ jobs:
         python-version: 3.8
     - name: Install dependencies
       run: |
+        pip install -r requirements.txt
+    - name: Install ANARCI
+      run: |
         python setup.py install
     - name: Test with pytest
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,24 @@
+name: Build & Test
+
+on:
+  push:
+  schedule:
+  - cron:  '0 3 * * 1'
+
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python setup.py install
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest ./test

--- a/bin/ANARCI
+++ b/bin/ANARCI
@@ -147,16 +147,8 @@ if __name__ == "__main__":
     
     # Check that hmmscan can be found in the path
     if args.hmmerpath:
-        hmmerpath=args.hmmerpath
-        scan_path = os.path.join( hmmerpath, "hmmscan" )
-        if not ( os.path.exists( scan_path ) and os.access(scan_path, os.X_OK)):
-            print("Error: No hmmscan executable file found in directory: %s"%(hmmerpath), file=sys.stderr)
-            sys.exit(1)
-    elif not which("hmmscan"):
-        print("Error: hmmscan was not found in the path. Either install and add to path or provide path with commandline option.", file=sys.stderr)
-        sys.exit(1)
-    
-    
+        print('Note: ANARCI is using pyhmmer, ignoring --hmmerpath argument')
+
     # Check if there should be some restriction as to which chain types should be numbered.
     # If it is not the imgt scheme they want then restrict to only igs (otherwise you'll hit assertion errors)
     types_to_chains = {"ig":["H","K","L"], "tr":["A", "B","G","D"], "heavy":["H"], "light":["K","L"] }

--- a/build_pipeline/BuildHMM.py
+++ b/build_pipeline/BuildHMM.py
@@ -1,0 +1,31 @@
+"""
+Build All.HMM from stockholm aligned file using PyHMMER
+"""
+
+import sys
+import pyhmmer
+
+
+def build(out_path, in_path):
+    alphabet = pyhmmer.easel.Alphabet.amino()
+    print('Loading MSA from {}'.format(in_path))
+    with pyhmmer.easel.MSAFile(in_path, digital=True, alphabet=alphabet) as msa_file:
+        msas = list(msa_file)
+
+    builder = pyhmmer.plan7.Builder(alphabet, architecture='hand')
+    background = pyhmmer.plan7.Background(alphabet)
+
+    print('Building HMMs from {} MSAs'.format(len(msas)))
+    hmms = []
+    with open(out_path, "wb") as output_file:
+        for msa in msas:
+            hmm, _, _ = builder.build_msa(msa, background)
+            hmm.write(output_file)
+            hmms.append(hmm)
+    print('Pressing HMMs')
+    pyhmmer.hmmpress(hmms, out_path)
+    print('Saved HMMs to {}'.format(out_path))
+
+
+if __name__ == '__main__':
+    build(sys.argv[1], sys.argv[2])

--- a/build_pipeline/RUN_pipeline.sh
+++ b/build_pipeline/RUN_pipeline.sh
@@ -15,10 +15,4 @@ python3 $DIR/FormatAlignments.py
 # Build the hmms for each species and chain.
 # --hand option required otherwise it will delete columns that are mainly gaps. We want 128 columns otherwise ARNACI will fall over.
 mkdir -p $DIR/HMMs
-hmmbuild --hand $DIR/HMMs/ALL.hmm $DIR/curated_alignments/ALL.stockholm
-#hmmbuild --hand $DIR/HMMs/ALL_AND_C.hmm $DIR/curated_alignments/ALL_AND_C.stockholm
-
-# Turn the output HMMs file into a binary form. This is required for hmmscan that is used in ARNACI.
-hmmpress -f $DIR/HMMs/ALL.hmm 
-#hmmpress -f $DIR/HMMs/ALL_AND_C.hmm
-
+python3 $DIR/BuildHMM.py $DIR/HMMs/ALL.hmm $DIR/curated_alignments/ALL.stockholm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-biopython
+pyhmmer

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ import shutil, os, subprocess, importlib
 if os.path.isdir("build"):
     shutil.rmtree("build/")
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 from distutils.core import setup
 
 setup(name='anarci',
@@ -20,6 +23,7 @@ setup(name='anarci',
       url='http://opig.stats.ox.ac.uk/webapps/ANARCI',
       packages=['anarci'], 
       package_dir={'anarci': 'lib/python/anarci'},
+      install_requires=requirements,
       #package_data={'anarci': ['dat/HMMs/ALL.hmm',
       #                         'dat/HMMs/ALL.hmm.h3f',
       #                         'dat/HMMs/ALL.hmm.h3i',

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,6 @@ import shutil, os, subprocess, importlib
 if os.path.isdir("build"):
     shutil.rmtree("build/")
 
-with open('requirements.txt') as f:
-    requirements = f.read().splitlines()
-
 from distutils.core import setup
 
 setup(name='anarci',
@@ -23,7 +20,6 @@ setup(name='anarci',
       url='http://opig.stats.ox.ac.uk/webapps/ANARCI',
       packages=['anarci'], 
       package_dir={'anarci': 'lib/python/anarci'},
-      install_requires=requirements,
       #package_data={'anarci': ['dat/HMMs/ALL.hmm',
       #                         'dat/HMMs/ALL.hmm.h3f',
       #                         'dat/HMMs/ALL.hmm.h3i',

--- a/test/test_hmmer.py
+++ b/test/test_hmmer.py
@@ -1,0 +1,45 @@
+import pytest
+from anarci import run_pyhmmer
+
+
+def test_run_pyhmmer():
+    sequence = 'QVQLQQSGAELARPGASVKMSCKASGYTFTRYTMHWVKQRPGQGLEWIGYINPSRGYTNYNQKFKDKATLTTDKSSSTAYMQLSSLTSEDSAVYYCARYYDDHYELVISCLDYWGQGTTLTVSS'
+    hit_table, state_vectors, top_descriptions = run_pyhmmer(
+        [('id', sequence)],
+        hmm_database='ALL',
+        ncpu=None,
+        bit_score_threshold=80,
+        hmmer_species=['human', 'mouse']
+    )[0]
+
+    state_vector = state_vectors[0]
+
+    hmm_states = [hmm_state for (hmm_state, state_type), sequence_index in state_vector]
+    state_types = ''.join(state_type for (hmm_state, state_type), sequence_index in state_vector)
+    sequence_reproduced = ''.join(sequence[sequence_index] if sequence_index is not None else '' for _, sequence_index in state_vector)
+
+    assert sequence == sequence_reproduced
+    #                      QVQLQQSGA-ELARPGASVKMSCKASGYTF----TRYTMHWVKQRPGQGLEWIGYINPS--RGYTNYNQKFK-DKATLTTDKSSSTAYMQLSSLTSEDSAVYYCARYYDDHYELVISCLDYWGQGTTLTVSS
+    assert state_types == 'mmmmmmmmmdmmmmmmmmmmmmmmmmmmmmddddmmmmmmmmmmmmmmmmmmmmmmmmmddmmmmmmmmmmmdmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmiiiimmmmmmmmmmmmmmmmmm'
+    assert hmm_states == list(range(1, 111)) + [111, 111, 111, 111, 111] + list(range(112, 129))
+
+    assert len(hit_table) == 3
+    assert hit_table[0] == ['id', 'description', 'evalue', 'bitscore', 'bias', 'query_start', 'query_end']
+    assert hit_table[1][0] == 'mouse_H'
+    assert hit_table[1][1] == ''
+    assert hit_table[1][2] == pytest.approx(1.6e-52)
+    assert hit_table[1][3] == pytest.approx(188.1, rel=1e-2)
+    assert hit_table[1][4] == pytest.approx(3.3, rel=1e-2)
+    assert hit_table[1][5] == 0
+    assert hit_table[1][6] == 124
+
+    assert len(top_descriptions) == 1
+    assert top_descriptions[0]['id'] == 'mouse_H'
+    assert top_descriptions[0]['description'] == ''
+    assert top_descriptions[0]['evalue'] == pytest.approx(1.6e-52)
+    assert top_descriptions[0]['bitscore'] == pytest.approx(188.1, rel=1e-2)
+    assert top_descriptions[0]['bias'] == pytest.approx(3.3, rel=1e-2)
+    assert top_descriptions[0]['query_start'] == 0
+    assert top_descriptions[0]['query_end'] == 124
+    assert top_descriptions[0]['chain_type'] == 'H'
+    assert top_descriptions[0]['species'] == 'mouse'

--- a/test/test_numbering.py
+++ b/test/test_numbering.py
@@ -1,0 +1,43 @@
+from anarci import number
+
+
+def test_imgt_heavy():
+    sequence = "QVQLQQSGAELARPGASVKMSCKASGYTFTRYTMHWVKQRPGQGLEWIGYINPSRGYTNYNQKFKDKATLTTDKSSSTAYMQLSSLTSEDSAVYYCARYYDDHYELVISCLDYWGQGTTLTVSS"
+    numbering, chain_type = number(sequence, "imgt")
+
+    assert chain_type == 'H'
+
+    positions = [f'{pos}{letter}'.strip() for (pos, letter), aa in numbering]
+    assert positions == [str(i) for i in range(1, 111)] + ['111', '111A', '111B', '112B', '112A'] + [str(i) for i in range(112, 129)]
+
+    aligned_sequence = ''.join(aa for (pos, letter), aa in numbering)
+    assert aligned_sequence == 'QVQLQQSGA-ELARPGASVKMSCKASGYTF----TRYTMHWVKQRPGQGLEWIGYINPS--RGYTNYNQKFK-DKATLTTDKSSSTAYMQLSSLTSEDSAVYYCARYYDDHYELVISCLDYWGQGTTLTVSS'
+
+    reproduced_sequence = ''.join(aa for (pos, letter), aa in numbering if aa != '-')
+    assert reproduced_sequence == sequence
+
+
+def test_imgt_light():
+    sequence = "DVVMTQSPLSLPVTLGQPASISCRSSQSLVYSDGNTYLNWFQQRPGQSPRRLIYKVSNRDSGVPDRFSGSGSGTDFTLKISRVEAEDVGVYYCMQGTFGQGTKVEIK"
+    numbering, chain_type = number(sequence, "imgt")
+
+    assert chain_type == 'L'  # L for light
+
+    positions = [f'{pos}{letter}'.strip() for (pos, letter), aa in numbering]
+    assert positions == [str(i) for i in range(1, 128)]
+
+    aligned_sequence = ''.join(aa for (pos, letter), aa in numbering)
+    assert aligned_sequence == 'DVVMTQSPLSLPVTLGQPASISCRSSQSLVYS-DGNTYLNWFQQRPGQSPRRLIYKV-------SNRDSGVP-DRFSGSG--SGTDFTLKISRVEAEDVGVYYCMQ---------GTFGQGTKVEIK'
+
+    reproduced_sequence = ''.join(aa for (pos, letter), aa in numbering if aa != '-')
+    assert reproduced_sequence == sequence
+
+
+def test_imgt_heavy_incomplete():
+    """Check that a few mismatching residues at N and C termini are treated as part of the aligned domain"""
+    sequence = "AAQLQQSGAELARPGASVKMSCKASGYTFTRYTMHWVKQRPGQGLEWIGYINPSRGYTNYNQKFKDKATLTTDKSSSTAYMQLSSLTSEDSAVYYCARYYDDHYELVISCLDYWGQGTTLTVAA"
+    numbering, chain_type = number(sequence, "imgt")
+
+    aligned_sequence = ''.join(aa for (pos, letter), aa in numbering)
+    assert aligned_sequence == 'AAQLQQSGA-ELARPGASVKMSCKASGYTF----TRYTMHWVKQRPGQGLEWIGYINPS--RGYTNYNQKFK-DKATLTTDKSSSTAYMQLSSLTSEDSAVYYCARYYDDHYELVISCLDYWGQGTTLTVAA'
+


### PR DESCRIPTION
This is the first step towards enabling `pip install anarci`.. I'm not sure if any other changes to setup.py will be needed to get there, we would need to try that out.

- Use pyhmmer instead of HMMER https://github.com/althonos/pyhmmer
  - Use pyhmmer instead of HMMER hmmbuild to build the HMM database
  - Use pyhmmer instead of HMMER hmmscan to find hits
- Add unit tests
- Run tests automatically each week, and also on each pull request using Github Actions

This way, ANARCI can be installed using:
```
pip install -r requirements.txt
python setup.py install
```

Speed is unaffected, I've observed just a slight increase in duration similar to the one reported here: https://github.com/althonos/pyhmmer#%EF%B8%8F-benchmarks

I'd be happy to hear your thoughts. 