### PR TITLE
Fix import for importlib.util

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 # Maintained by members of OPIG #
 #                               #
 
-import shutil, os, subprocess, importlib
+import shutil, os, subprocess, importlib.util
 # Clean this out if it exists
 if os.path.isdir("build"):
     shutil.rmtree("build/")


### PR DESCRIPTION
Fixes #44 
Relevant information in the answer to https://stackoverflow.com/questions/39660934/error-when-using-importlib-util-to-check-for-library (not by me)