### PR TITLE
Remove unnecessary dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ANARCI -i myfile.fasta
 The easiest way to install ANARCI and its dependencies is using conda
 
 ```python
-conda install -c conda-forge openmm pdbfixer biopython -y
+conda install -c conda-forge biopython -y
 conda install -c bioconda hmmer=3.3.2 -y
 cd ANARCI
 python setup.py install


### PR DESCRIPTION
Remove unnecessary dependencies in README - openmm and pdbfixer are only needed for ImmuneBuilder, not for ANARCI